### PR TITLE
Update to Swift 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@
 # * http://www.objc.io/issue-6/travis-ci.html
 # * https://github.com/supermarin/xcpretty#usage
 
-osx_image: xcode7.2
+osx_image: xcode7.3
 language: objective-c
 
 branches:
  only:
  - master
+
+before_install:
+    - brew uninstall xctool && brew install --HEAD xctool
 
 install:
     - gem install cocoapods -v 0.38.2 --no-document
@@ -18,4 +21,4 @@ before_script:
 
 xcode_workspace: NumberMorphView.xcworkspace
 xcode_scheme: NumberMorphView-Example
-xcode_sdk: iphonesimulator9.2
+xcode_sdk: iphonesimulator9.3

--- a/Example/NumberMorphView/ViewController.swift
+++ b/Example/NumberMorphView/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated);
         
-        NSTimer.scheduledTimerWithTimeInterval(1, target: self, selector: Selector("updateTime"), userInfo: nil, repeats: true);
+        NSTimer.scheduledTimerWithTimeInterval(1, target: self, selector: #selector(ViewController.updateTime), userInfo: nil, repeats: true);
         n1.interpolator = NumberMorphView.LinearInterpolator();
         n2.interpolator = NumberMorphView.OvershootInterpolator();
         n3.interpolator = NumberMorphView.SpringInterpolator();

--- a/Pod/Classes/NumberMorphView.swift
+++ b/Pod/Classes/NumberMorphView.swift
@@ -249,7 +249,7 @@ public class NumberMorphView: UIView {
         
         self.layer.addSublayer(shapeLayer);
         
-        displayLink = CADisplayLink(target: self, selector: Selector("updateAnimationFrame"));
+        displayLink = CADisplayLink(target: self, selector: #selector(NumberMorphView.updateAnimationFrame));
         displayLink.frameInterval = 1;
         displayLink.paused = true;
         displayLink.addToRunLoop(NSRunLoop.currentRunLoop(), forMode: NSRunLoopCommonModes);

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ class MyLinearInterpolator: InterpolatorProtocol {
 ## Requirements
 
 - iOS 8.0+
-- Swift 2.0
+- Swift 2.2
 
 ## Installation
 


### PR DESCRIPTION
This commit fixes 2 warnings: "Use '#selector' instead of explicitly constructing a 'Selector'".
